### PR TITLE
the location of the configuration file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,8 @@ prometheus_alertmanager_log_dir: /var/log/prometheus
 prometheus_alertmanager_listen_address: ':9093'
 prometheus_alertmanager_external_url: 'http://localhost:9093/'
 
+prometheus_alertmanager_config_parts_src_dir: "{{ playbook_dir }}/files/alertmanager_config_parts"
+prometheus_alertmanager_templates_src_dir: "{{ playbook_dir }}/files/templates"
 prometheus_alertmanager_templates_files: []
 
 prometheus_alertmanager_resolve_timeout: 5m

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -16,7 +16,7 @@
     group: "{{ prometheus_alertmanager_group }}"
     mode: 0644
   with_fileglob:
-    - "{{ playbook_dir }}/files/alertmanager_config_parts/*"
+    - "{{ prometheus_alertmanager_config_parts_src_dir }}/*"
 
 - name: create main config from parts
   assemble:
@@ -32,7 +32,7 @@
 
 - name: copy templates files from playbook directory
   copy:
-    src: "{{ playbook_dir }}/files/templates/{{ item }}"
+    src: "{{ prometheus_alertmanager_templates_src_dir }}/{{ item }}"
     dest: "{{ prometheus_alertmanager_templates_dir }}/{{ item }}"
     owner: "{{ prometheus_alertmanager_user }}"
     group: "{{ prometheus_alertmanager_group }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
     recurse: yes
     owner: "{{ prometheus_alertmanager_user}}"
     group: "{{ prometheus_alertmanager_group }}"
-  when: prometheus_alertmanager_updated | changed
+  when: prometheus_alertmanager_updated is changed
   
 - name: create symlink to the current release
   file:


### PR DESCRIPTION
1. Provide variables that can be customized by the user

    ```
    prometheus_alertmanager_config_parts_src_dir
    prometheus_alertmanager_templates_src_dir
    ```

2. Ansible after version 2.5, abolished the **changed** filter

    https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#deprecated